### PR TITLE
continuous display improvement

### DIFF
--- a/Software/Photonfirmware/AnimatronicEyesTest/src/AnimatronicEyes.ino
+++ b/Software/Photonfirmware/AnimatronicEyesTest/src/AnimatronicEyes.ino
@@ -56,13 +56,24 @@ TPP_TOF theTOF;
 const long IDLE_SEQUENCE_MIN_WAIT_MS = 10000; //30 sec // during idle times, random activity will happen longer than this
 const long TOF_SAMPLE_TIME = 25;   // the TOF only updated 10x/sec, so don't need to upload the TOF data very often
 
-SerialLogHandler logHandler1(LOG_LEVEL_INFO, {  // Logging level for non-application messages LOG_LEVEL_ALL or _INFO
-    { "app.main", LOG_LEVEL_ALL }               // Logging for main loop
-    ,{ "app.puppet", LOG_LEVEL_INFO }               // Logging for Animate puppet methods
-    ,{ "app.anilist", LOG_LEVEL_ERROR }               // Logging for Animation List methods
-    ,{ "app.aniservo", LOG_LEVEL_INFO }          // Logging for Animate Servo details
-    ,{"comm.protocol", LOG_LEVEL_WARN}          // particle communication system 
-});
+//
+#ifdef DEBUGON
+    SerialLogHandler logHandler1(LOG_LEVEL_INFO, {  // Logging level for non-application messages LOG_LEVEL_ALL or _INFO
+        { "app.main", LOG_LEVEL_ALL }               // Logging for main loop
+        ,{ "app.puppet", LOG_LEVEL_INFO }               // Logging for Animate puppet methods
+        ,{ "app.anilist", LOG_LEVEL_ERROR }               // Logging for Animation List methods
+        ,{ "app.aniservo", LOG_LEVEL_INFO }          // Logging for Animate Servo details
+        ,{"comm.protocol", LOG_LEVEL_WARN}          // particle communication system 
+    });
+#else
+    SerialLogHandler logHandler1(LOG_LEVEL_ERROR, {  // Logging level for non-application messages LOG_LEVEL_ALL or _INFO
+        { "app.main", LOG_LEVEL_ERROR }               // Logging for main loop
+        ,{ "app.puppet", LOG_LEVEL_ERROR }               // Logging for Animate puppet methods
+        ,{ "app.anilist", LOG_LEVEL_ERROR }               // Logging for Animation List methods
+        ,{ "app.aniservo", LOG_LEVEL_ERROR }          // Logging for Animate Servo details
+        ,{"comm.protocol", LOG_LEVEL_ERROR}          // particle communication system 
+    });
+#endif
 
 Logger mainLog("app.main");
 

--- a/Software/Photonfirmware/AnimatronicEyesTest/src/TPP_TOF.cpp
+++ b/Software/Photonfirmware/AnimatronicEyesTest/src/TPP_TOF.cpp
@@ -274,14 +274,11 @@ void TPP_TOF::getPOI(pointOfInterest *pPOI){
             // process the measured data
             processMeasuredData(measurementData, adjustedData);
             
-#ifdef CONTINUOUS_DEBUG_DISPLAY
-            prettyPrint(adjustedData);
-#endif
             // XXXX New criteria (v 0.8+ for establishing the smallest valid distance)
             //  Walk through the adjustedData array except for the edges.  For each possible
             //    smallest value found, check that surrounding values asre valid.
 
-            secondTableTitle = "avgDistThisZone";
+            //
             // do not process the edges: x, y == 0 or x,y == 7  
             for (int y = 0; y < imageWidth; y++) {
                 for (int x = 0; x < imageWidth; x++) {
@@ -308,6 +305,10 @@ void TPP_TOF::getPOI(pointOfInterest *pPOI){
             }
 
 #ifdef CONTINUOUS_DEBUG_DISPLAY
+
+            int linesPrinted = 0;
+            linesPrinted = prettyPrint(adjustedData);
+
             // print out focus value found
             Serial.print("\nFocus on x = ");
             Serial.printf("%-5ld", focusX);
@@ -318,13 +319,16 @@ void TPP_TOF::getPOI(pointOfInterest *pPOI){
             Serial.println();
             Serial.println();
             Serial.println();
+            linesPrinted += 3;
 
-            Serial.println(secondTableTitle);
-            prettyPrint(secondTable);
+            Serial.println("avgDistThisZone");
+            linesPrinted += 1;
+            linesPrinted += prettyPrint(secondTable);
             Serial.println();
+            linesPrinted++;
 
-            // XXX overwrite the previous display
-            moveTerminalCursorUp(22);
+            // overwrite the previous display
+            moveTerminalCursorUp(linesPrinted+1);
 #endif
             
         }
@@ -342,15 +346,19 @@ void TPP_TOF::getPOI(pointOfInterest *pPOI){
 
 /* ------------------------------ */
 // function to pretty print data to serial port
-void TPP_TOF::prettyPrint(int32_t dataArray[]) {
+//   retuns number of lines printed
+int TPP_TOF::prettyPrint(int32_t dataArray[]) {
     //The ST library returns the data transposed from zone mapping shown in datasheet
     //Pretty-print data with increasing y, decreasing x to reflect reality 
 
+    int lines = 0;
     for(int y = 0; y <= imageWidth * (imageWidth - 1) ; y += imageWidth)  {
         for (int x = imageWidth - 1 ; x >= 0 ; x--) {
             Serial.print("\t");
             Serial.printf("%-5ld", dataArray[x + y]);
         }
         Serial.println();
+        lines++;
     } 
+    return lines;
 }

--- a/Software/Photonfirmware/AnimatronicEyesTest/src/TPP_TOF.h
+++ b/Software/Photonfirmware/AnimatronicEyesTest/src/TPP_TOF.h
@@ -24,7 +24,7 @@
 #ifndef _TPP_TOF_H
 #define _TPP_TOF_H
 
-#define CONTINUOUS_DEBUG_DISPLAY
+//#define CONTINUOUS_DEBUG_DISPLAY
 
 #include <SparkFun_VL53L5CX_Library.h> //http://librarymanager/All#SparkFun_VL53L5CX
 #include <Wire.h>

--- a/Software/Photonfirmware/AnimatronicEyesTest/src/TPP_TOF.h
+++ b/Software/Photonfirmware/AnimatronicEyesTest/src/TPP_TOF.h
@@ -24,7 +24,7 @@
 #ifndef _TPP_TOF_H
 #define _TPP_TOF_H
 
-//#define CONTINUOUS_DEBUG_DISPLAY
+#define CONTINUOUS_DEBUG_DISPLAY
 
 #include <SparkFun_VL53L5CX_Library.h> //http://librarymanager/All#SparkFun_VL53L5CX
 #include <Wire.h>
@@ -49,7 +49,7 @@ public:
     void getPOI(pointOfInterest *pPOI);
 
 private:
-    void prettyPrint(int32_t dataArray[]);
+    int prettyPrint(int32_t dataArray[]);
     void processMeasuredData(VL53L5CX_ResultsData measurementData, int32_t adjustedData[]);
     int  scoreZone(int location, int32_t dataArray[]);
     int  avgdistZone(int location, int32_t distance[]);


### PR DESCRIPTION
Continuous display is when we show the sensor output over and over again. There is a #define in TPP_TOF.h to turn this on. When doing that you need to also turn off DEBUGON in the main code. However, this was not set up correctly. My mistake and I've fixed it.

Also consolidated the continuous display code so it is easier to maintain.