### PR TITLE
Personalities

### DIFF
--- a/Software/Photonfirmware/AnimatronicEyesTest/src/AnimatronicEyes.ino
+++ b/Software/Photonfirmware/AnimatronicEyesTest/src/AnimatronicEyes.ino
@@ -12,8 +12,9 @@
  *      the welcome sequence and return to "sleeping".
  *
  * (cc) Share Alike - Non Commercial - Attibution
- * 2020 Bob Glicksman and Jim Schrempp
+ * 2022 Bob Glicksman and Jim Schrempp
  * 
+ *      added temporal filtering
  * v1.8 changed the TOF upload time in loop to be longer (25 ms)
  * v1.7 add TOF event processing
  * v1.6 Exponential decay on the servo moves
@@ -49,14 +50,13 @@ SYSTEM_THREAD(ENABLED);  // added this in an attempt to get the software timer t
 
 TPP_TOF theTOF;
 
-#define DEBUGON
+// #define DEBUGON
 #define TRIGGER_PIN A5
 #define KILL_BUTTON_PIN A4
 
 const long IDLE_SEQUENCE_MIN_WAIT_MS = 10000; //30 sec // during idle times, random activity will happen longer than this
 const long TOF_SAMPLE_TIME = 25;   // the TOF only updated 10x/sec, so don't need to upload the TOF data very often
 
-//
 #ifdef DEBUGON
     SerialLogHandler logHandler1(LOG_LEVEL_INFO, {  // Logging level for non-application messages LOG_LEVEL_ALL or _INFO
         { "app.main", LOG_LEVEL_ALL }               // Logging for main loop
@@ -72,6 +72,7 @@ const long TOF_SAMPLE_TIME = 25;   // the TOF only updated 10x/sec, so don't nee
         ,{ "app.anilist", LOG_LEVEL_ERROR }               // Logging for Animation List methods
         ,{ "app.aniservo", LOG_LEVEL_ERROR }          // Logging for Animate Servo details
         ,{"comm.protocol", LOG_LEVEL_ERROR}          // particle communication system 
+        ,{"app.TOF", LOG_LEVEL_TRACE}
     });
 #endif
 
@@ -195,6 +196,8 @@ void setup() {
     pinMode(TRIGGER_PIN, INPUT);
     pinMode(KILL_BUTTON_PIN,INPUT_PULLUP);
 
+    pinMode(D7, OUTPUT);
+
     delay(1000);
     mainLog.info("===========================================");
     mainLog.info("===========================================");
@@ -290,7 +293,8 @@ void loop() {
         // this is called every time to allow TOF to make measurements
         pointOfInterest thisPOI;
 
-        theTOF.getPOI(&thisPOI);
+        //theTOF.getPOI(&thisPOI);
+        theTOF.getPOITemporalFiltered(&thisPOI);
         focusX = thisPOI.x;
         focusY = thisPOI.y;
         //smallestValue = thisPOI.distanceMM;

--- a/Software/Photonfirmware/AnimatronicEyesTest/src/TPP_TOF.h
+++ b/Software/Photonfirmware/AnimatronicEyesTest/src/TPP_TOF.h
@@ -47,6 +47,7 @@ class TPP_TOF {
 public:
     void initTOF();
     void getPOI(pointOfInterest *pPOI);
+    void getPOITemporalFiltered(pointOfInterest *pPOI);
 
 private:
     int prettyPrint(int32_t dataArray[]);


### PR DESCRIPTION
I found some interesting things about the TOF. If you want to experiment yourself, uncomment this line in the main .ino file

     // #define DEBUGON

And then modify the two new #defines I list below.

In the code I added a new method to the TOF object:

    getPOITemporalFiltered

This calls the original getPOI() but then debounces the result. I currently require two hits within a time frame or else I just return the -255 "no hit". I added a logging report whenever the temporal filter is exceeded, so we can see when a point is returned. Watching the serial monitor you can see when these spurious hits occur.

I initially set the filter time to 250ms. That stopped all false reports! I reduced it to 125ms and started getting some spurious reports. This led me to think that the optimal filter time might depend on the ranging frequency. So I did some tests.

1. I added two defines and calculate the debounce time from them:

     #define RANGING_FREQUENCY 16   // times per second for sensor to sample the environment
     #define FRAMES_FOR_GOOD_HIT 4 // number of subsequent frames needed to consider a hit good
                                                         // this filters out spurious hits

The two settings above (16:4) equate to a 250ms debounce time. This yields no spurious reports, as expected.

2. My first test was (4:1) which is slower ranging but is also a 250ms debounce. This also has no spurious reports!

3. I did some runs with different frequencies, keeping the frames at 1 so I could get an idea of the base false reports. Then I could increase the frames required to give us the fastest ranging with the minimum required debounce time. I found that as the ranging frequency increases, the spurious reports go up.

    (8:1) was quiet for 60 seconds, then had three spurious reports at one x,y.  Then quiet for 13 seconds, and another three bad reports at another x,y.
    (10:1) was quiet for 27 seconds then two spurious. Quiet for 76 seconds, and another two bad reports.
    (12:1) was quiet for 32 seconds, then a spurious report.

Interesting that a group of spurious results are all at a particular x,y, but that the next group is at a different x,y. I wonder if some thermal air current causes these spurious reports.

4. It looks like (14:2) gives us a good result. It's been running a long time without a spurious report. This is what I've checked in.