### PR TITLE
v 1.9 Better suppression of spurious POI reports

### DIFF
--- a/Software/Photonfirmware/AnimatronicEyesTest/src/AnimatronicEyes.ino
+++ b/Software/Photonfirmware/AnimatronicEyesTest/src/AnimatronicEyes.ino
@@ -14,6 +14,9 @@
  * (cc) Share Alike - Non Commercial - Attibution
  * 2022 Bob Glicksman and Jim Schrempp
  * 
+ * v1.9 temporal filtering now requires 2 frames of the same x,y 
+ *      calibration now looks for several close frames
+ *      changed pretty print x titles of calibration array to be correct 
  *      added temporal filtering
  * v1.8 changed the TOF upload time in loop to be longer (25 ms)
  * v1.7 add TOF event processing

--- a/Software/Photonfirmware/AnimatronicEyesTest/src/AnimatronicEyes.ino
+++ b/Software/Photonfirmware/AnimatronicEyesTest/src/AnimatronicEyes.ino
@@ -64,7 +64,7 @@ const long TOF_SAMPLE_TIME = 25;   // the TOF only updated 10x/sec, so don't nee
         ,{ "app.anilist", LOG_LEVEL_ERROR }               // Logging for Animation List methods
         ,{ "app.aniservo", LOG_LEVEL_INFO }          // Logging for Animate Servo details
         ,{"comm.protocol", LOG_LEVEL_WARN}          // particle communication system 
-        ,{"app.TOF", LOG_LEVEL_INFO}
+        ,{"app.TOF", LOG_LEVEL_TRACE}
     });
 #else
     SerialLogHandler logHandler1(LOG_LEVEL_ERROR, {  // Logging level for non-application messages LOG_LEVEL_ALL or _INFO
@@ -308,15 +308,15 @@ void loop() {
 
         //smallestValue = thisPOI.distanceMM;
 
-        // XXXX call function to process the TOF data for event publication
-
-        processEvents(focusX, focusY, thisPOI.distanceMM);
-
         // do we have a focus point?
         if (thisPOI.hasDetection) {
 
             focusX = thisPOI.x;
             focusY = thisPOI.y;
+
+            // XXXX call function to process the TOF data for event publication
+
+            processEvents(focusX, focusY, thisPOI.distanceMM);
 
             lastEyeUpdateMS = millis();
 

--- a/Software/Photonfirmware/AnimatronicEyesTest/src/AnimatronicEyes.ino
+++ b/Software/Photonfirmware/AnimatronicEyesTest/src/AnimatronicEyes.ino
@@ -192,6 +192,12 @@ void animationTimerCallback() {
     }
 }
 
+// Cloud functions must return int and take one String
+int restartDevice(String extra) {
+    System.reset();
+    return 0;
+}
+
 //------ setup -----------
 void setup() {
 
@@ -199,6 +205,8 @@ void setup() {
     pinMode(KILL_BUTTON_PIN,INPUT_PULLUP);
 
     pinMode(D7, OUTPUT);
+
+    Particle.function("restart device", restartDevice);
 
     delay(1000);
     mainLog.info("===========================================");

--- a/Software/Photonfirmware/AnimatronicEyesTest/src/TPP_TOF.cpp
+++ b/Software/Photonfirmware/AnimatronicEyesTest/src/TPP_TOF.cpp
@@ -354,6 +354,7 @@ void TPP_TOF::getPOI(pointOfInterest *pPOI){
                             && (validate(score))                                 // has at least x adjacent zones with valid distances 
                             && (adjustedData[thisZone] < calibration[thisZone])   // closer than our calibration frame (this does not seem to matter)
                             && (adjustedData[thisZone] < pPOI->distanceMM)       // closer than current closest pPOI
+                            && (avgDistThisZone > NOISE_RANGE)
                             ) {
                         // this pPOI will be the one closest to the sensor
                         pPOI->x  = x;


### PR DESCRIPTION
This is not perfect. Changes:

1. Calibration frame is now taken by waiting until two successive frames report similar distances.
2. Temporal filtering now requires two reports of the same (x,y) in succession before reporting a POI
3. A cloud function will reset the device - this facilitates testing the TOF without accidentally moving it.
4. Mouth events are now sent (bug fix)
5. The x labels on the print of the calibration frame are now correct, 7 on the left and 0 on the right