### PR TITLE
Goodbye events are now working

### DIFF
--- a/Software/Photonfirmware/AnimatronicEyesTest/src/AnimatronicEyes.ino
+++ b/Software/Photonfirmware/AnimatronicEyesTest/src/AnimatronicEyes.ino
@@ -67,6 +67,7 @@ const long TOF_SAMPLE_TIME = 25;   // the TOF only updated 10x/sec, so don't nee
         ,{ "app.anilist", LOG_LEVEL_ERROR }               // Logging for Animation List methods
         ,{ "app.aniservo", LOG_LEVEL_INFO }          // Logging for Animate Servo details
         ,{"comm.protocol", LOG_LEVEL_WARN}          // particle communication system 
+        ,{"comm.dtls", LOG_LEVEL_WARN}          // particle communication system 
         ,{"app.TOF", LOG_LEVEL_TRACE}
     });
 #else
@@ -75,7 +76,8 @@ const long TOF_SAMPLE_TIME = 25;   // the TOF only updated 10x/sec, so don't nee
         ,{ "app.puppet", LOG_LEVEL_ERROR }               // Logging for Animate puppet methods
         ,{ "app.anilist", LOG_LEVEL_ERROR }               // Logging for Animation List methods
         ,{ "app.aniservo", LOG_LEVEL_ERROR }          // Logging for Animate Servo details
-        ,{"comm.protocol", LOG_LEVEL_ERROR}          // particle communication system 
+        ,{"comm.protocol", LOG_LEVEL_WARN}          // particle communication system 
+        ,{"comm.dtls", LOG_LEVEL_ERROR}          // particle communication system 
         ,{"app.TOF", LOG_LEVEL_TRACE}
         
     });
@@ -311,15 +313,21 @@ void loop() {
 
         //smallestValue = thisPOI.distanceMM;
 
+        // XXXX call function to process the TOF data for event publication
+
+        // xxx this is a hack for now. 
+        // xxx  we should really pass thisPOI into processEvents and let it make decisions
+        if (thisPOI.hasDetection) {
+            processEvents(thisPOI.x, thisPOI.y, thisPOI.distanceMM);
+        } else {
+            processEvents(-1, -1, thisPOI.distanceMM);
+        }
+        
         // do we have a focus point?
         if (thisPOI.hasDetection) {
 
             focusX = thisPOI.x;
             focusY = thisPOI.y;
-
-            // XXXX call function to process the TOF data for event publication
-
-            processEvents(focusX, focusY, thisPOI.distanceMM);
 
             lastEyeUpdateMS = millis();
 


### PR DESCRIPTION
In updating the new TOF code, it returns a more nuanced set of state variables. In the main loop we used to call the mouth event code every time through the loop, relying on the x,y values being -255 when there was no POI. These calls would be used to check if someone had left the field of view. With the new TOF object I need to change the mouth event code to use these new state variables.

This commit is a quick hack to get things working. If the POI structure has data, then those values are passed to the mouth event code. If the POI structure has no data, then -1, -1 are passed to the mouth event code.