### PR TITLE
Fix for saying goodbye while standing in front of head

### DIFF
--- a/Software/Photonfirmware/AnimatronicEyesTest/src/TPP_TOF.cpp
+++ b/Software/Photonfirmware/AnimatronicEyesTest/src/TPP_TOF.cpp
@@ -448,8 +448,8 @@ void TPP_TOF::getPOITemporalFiltered(pointOfInterest *pPOI) {
         } 
         
         // allow some spatial jitter
-        int spatialDistX = currentX == pPOI->x;
-        int spatialDistY = currentY == pPOI->y;
+        int spatialDistX = 0 ;  //currentX - pPOI->x;
+        int spatialDistY = 0 ;  //currentY - pPOI->y;
         if ((spatialDistX < 2) && (spatialDistY < 2)) {
             // same x,y so increment frame counter
             sequentialFramesWithHit++;

--- a/Software/Photonfirmware/AnimatronicEyesTest/src/TPP_TOF.cpp
+++ b/Software/Photonfirmware/AnimatronicEyesTest/src/TPP_TOF.cpp
@@ -447,7 +447,10 @@ void TPP_TOF::getPOITemporalFiltered(pointOfInterest *pPOI) {
             suppressedY = -1;
         } 
         
-        if ((currentX == pPOI->x) && (currentY == pPOI->y)) {
+        // allow some spatial jitter
+        int spatialDistX = currentX == pPOI->x;
+        int spatialDistY = currentY == pPOI->y;
+        if ((spatialDistX < 2) && (spatialDistY < 2)) {
             // same x,y so increment frame counter
             sequentialFramesWithHit++;
         } else {


### PR DESCRIPTION
My previous attempt to reduce spurious hits added that sequential detections must report the same x,y. In reality, the detection often moves around a bit - consider the person just moving slightly. That caused the chain of sequential hits to break and we'd report "no hit". This caused a "goodbye" message.

With this fix I disable the requirement for hits to be in the same x,y

I've run this in my head with the mouth running and the problem has gone away.

